### PR TITLE
fix: `RenewalInputs`의 isRequired prop을 네이밍에 맞춘 용도로 수정

### DIFF
--- a/src/components/RenewalInputs/AuthInputWithLabel/index.jsx
+++ b/src/components/RenewalInputs/AuthInputWithLabel/index.jsx
@@ -11,14 +11,14 @@ export const AuthInputWithLabel = ({
   placeholder,
   value,
   onChange,
-  isRequired = false,
+  isRequired = true,
 }) => {
   return (
       <Wrapper isLabelTitle={labelTitle}>
         {labelTitle && (
           <StyledLabel htmlFor={inputName}>{labelTitle}</StyledLabel>
         )}
-        {isRequired && <StyledRequiredText>(선택)</StyledRequiredText>}
+        {!isRequired && <StyledRequiredText>(선택)</StyledRequiredText>}
         <StyledInput
           name={inputName}
           type={inputType}

--- a/src/components/RenewalInputs/AuthTextAreaWithLabel/index.jsx
+++ b/src/components/RenewalInputs/AuthTextAreaWithLabel/index.jsx
@@ -11,14 +11,14 @@ export const AuthTextAreaWithLabel = ({
   placeholder,
   value,
   onChange,
-  isRequired = false
+  isRequired = true
 }) => {
   return (
     <Wrapper isLabelTitle={labelTitle}>
       {labelTitle && (
         <StyledLabel htmlFor={inputName}>{labelTitle}</StyledLabel>
       )}
-      {isRequired && (
+      {!isRequired && (
         <StyledRequiredText>(선택)</StyledRequiredText>
       )}
       <StyledTextArea

--- a/src/pages/RenewalJoinPage/JoinForm/index.jsx
+++ b/src/pages/RenewalJoinPage/JoinForm/index.jsx
@@ -164,7 +164,7 @@ function JoinForm() {
         placeholder='최대 200자 이내로 작성해주세요.'
         value={detail_comment}
         onChange={onChange}
-        isRequired={true}
+        isRequired={false}
       />
 
       <AuthInputWithLabel
@@ -174,7 +174,7 @@ function JoinForm() {
         placeholder='깃헙 주소 ex) https://github.com/'
         value={github_id}
         onChange={onChange}
-        isRequired={true}
+        isRequired={false}
       />
 
       <AuthInputWithLabel


### PR DESCRIPTION
## 변경사항


- `AuthInputWithLabel` 과 `AuthTextAreaWithLabel` 에 사용되는 `isRequired` prop이 네이밍과 다르게 사용된 것 같아서 수정했습니다.
- 기본값이 `isRequired = true` 라서 필수 입력이 아닐 때만 `isRequired = {false}` 식으로 사용하면 됩니다.